### PR TITLE
Lazy connection allows for URLs that are unknown at plan time.

### DIFF
--- a/internal/provider/data_query.go
+++ b/internal/provider/data_query.go
@@ -93,7 +93,12 @@ func (d *dataQuery) Read(ctx context.Context, config map[string]tftypes.Value) (
 		return nil, nil, err
 	}
 
-	rows, err := d.db.QueryContext(ctx, query)
+	diag, err := d.p.ConnectLazy(ctx)
+	if diag != nil || err != nil {
+		return nil, diag, err
+	}
+
+	rows, err := d.p.DB.QueryContext(ctx, query)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"math/big"
-	"os"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -38,6 +37,10 @@ type provider struct {
 	DB *sql.DB `argmapper:",typeOnly"`
 
 	Driver driverName
+
+	Url          tftypes.Value
+	MaxOpenConns int64
+	MaxIdleConns int64
 }
 
 var _ server.Provider = (*provider)(nil)
@@ -89,76 +92,48 @@ func (p *provider) Configure(ctx context.Context, config map[string]tftypes.Valu
 
 	var err error
 
-	var (
-		url          string
-		maxOpenConns *big.Float
-		maxIdleConns *big.Float
-	)
-	if v := config["url"]; v.IsNull() {
-		url = os.Getenv("SQL_URL")
-	} else {
-		err = config["url"].As(&url)
+	p.Url = config["url"]
+	if p.Url.IsKnown() {
+		_, err = p.validateUrl()
 		if err != nil {
-			// TODO: diag with path
-			return nil, fmt.Errorf("ConfigureProvider - unable to read url: %w", err)
+			return nil, fmt.Errorf("ConfigureProvider - invalid url: %w", err)
 		}
 	}
 
-	if url == "" {
-		return []*tfprotov6.Diagnostic{
-			{
-				Severity: tfprotov6.DiagnosticSeverityError,
-				Attribute: tftypes.NewAttributePathWithSteps([]tftypes.AttributePathStep{
-					tftypes.AttributeName("url"),
-				}),
-				Summary: "A `url` is required to connect to your database.",
-			},
-		}, nil
-	}
-
 	if v := config["max_open_conns"]; v.IsNull() {
-		maxOpenConns = big.NewFloat(float64(0))
+		p.MaxOpenConns = 0
 	} else {
-		maxOpenConns = &big.Float{}
-		err = config["max_open_conns"].As(&maxOpenConns)
+		maxOpenConnsBig := &big.Float{}
+		err = v.As(&maxOpenConnsBig)
 		if err != nil {
 			// TODO: diag with path
 			return nil, fmt.Errorf("ConfigureProvider - unable to read max_open_conns: %w", err)
 		}
+
+		maxOpenConns, acc := maxOpenConnsBig.Int64()
+		if acc != big.Exact {
+			return nil, fmt.Errorf("ConfigureProvider - max_open_conns must be an integer")
+		}
+
+		p.MaxOpenConns = maxOpenConns
 	}
 
 	if v := config["max_idle_conns"]; v.IsNull() {
-		maxIdleConns = big.NewFloat(float64(2))
+		p.MaxIdleConns = 2
 	} else {
-		maxIdleConns = &big.Float{}
-		err = v.As(&maxIdleConns)
+		maxIdleConnsBig := &big.Float{}
+		err = v.As(&maxIdleConnsBig)
 		if err != nil {
 			// TODO: diag with path
 			return nil, fmt.Errorf("ConfigureProvider - unable to read max_idle_conns: %w", err)
 		}
-	}
 
-	err = p.connect(url)
-	if err != nil {
-		return nil, fmt.Errorf("ConfigureProvider - unable to open database: %w", err)
-	}
+		maxIdleConns, acc := maxIdleConnsBig.Int64()
+		if acc != big.Exact {
+			return nil, fmt.Errorf("ConfigureProvider - max_idle_conns must be an integer")
+		}
 
-	maxOpen, acc := maxOpenConns.Int64()
-	if acc != big.Exact {
-		return nil, fmt.Errorf("ConfigureProvider - results for max_open_conns is not exact")
-	}
-
-	maxIdle, acc := maxIdleConns.Int64()
-	if acc != big.Exact {
-		return nil, fmt.Errorf("ConfigureProvider - results for max_open_conns is not exact")
-	}
-
-	p.DB.SetMaxOpenConns(int(maxOpen))
-	p.DB.SetMaxIdleConns(int(maxIdle))
-
-	err = p.DB.PingContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("ConfigureProvider - unable to ping database: %w", err)
+		p.MaxIdleConns = maxIdleConns
 	}
 
 	return nil, nil

--- a/internal/provider/resource_migrate.go
+++ b/internal/provider/resource_migrate.go
@@ -19,10 +19,11 @@ type resourceMigrate struct {
 var _ server.Resource = (*resourceMigrate)(nil)
 var _ server.ResourceUpdater = (*resourceMigrate)(nil)
 
-func newResourceMigrate(db dbExecer) (*resourceMigrate, error) {
+func newResourceMigrate(db dbExecer, p *provider) (*resourceMigrate, error) {
 	return &resourceMigrate{
 		resourceMigrateCommon: resourceMigrateCommon{
 			db: db,
+			p:  p,
 		},
 	}, nil
 }


### PR DESCRIPTION
This moves the database connection to the apply phase, meaning that it allows database URLs that are not yet known at validation time, either because the DB itself is being created in the same workspace, or because the URL is built up with information retrieved from a data resource.

This is my first time using Go, and I have doubts about how the provider is being passed to the resources. Namely, before it was via the dbQueryer / dbExecer interfaces, but since the connecting was moved to the Create/Update/Destroy functions, it would actually panic due to a nil reference when doing the queries. I'm sure it has something to do with pointers. I'm not experienced enough to know why just passing the provider reference is bad, but at least it's working.